### PR TITLE
Update CI test matrix to use standard Julia version aliases

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '1.9'
+          - 'lts'
+          - '1'
           - 'pre'
         os:
           - ubuntu-latest


### PR DESCRIPTION
## Summary
- Changed CI test matrix from specific versions (`1.6`, `1.9`, `pre`) to standard aliases (`lts`, `1`, `pre`)
- This follows standard SciML/Julia ecosystem conventions
- Aliases automatically track the latest LTS and stable Julia versions without manual updates

## Test plan
- [x] Local tests pass
- [ ] CI passes on all three Julia versions (lts, 1, pre)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)