### PR TITLE
Interface compatibility: add ArrayInterface checks and relax type signatures

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "1.0.0"
 authors = ["Anastasia Dunca"]
 
 [deps]
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
@@ -23,6 +24,7 @@ SpecialMatricesExt = "SpecialMatrices"
 ToeplitzMatricesExt = "ToeplitzMatrices"
 
 [compat]
+ArrayInterface = "7"
 BandedMatrices = "1.10.2"
 BlockBandedMatrices = "0.13.4"
 FastAlmostBandedMatrices = "0.1.5"
@@ -37,9 +39,10 @@ BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
 FastAlmostBandedMatrices = "9d29842c-ecb8-4973-b1e9-a27b1157504e"
+JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 SpecialMatrices = "928aab9d-ef52-54ac-8ca1-acd7ca42c160"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ToeplitzMatrices = "c751599d-da0a-543b-9d20-d0a503d91d24"
 
 [targets]
-test = ["AllocCheck", "BandedMatrices", "BenchmarkTools", "BlockBandedMatrices", "FastAlmostBandedMatrices", "SpecialMatrices", "Test", "ToeplitzMatrices"]
+test = ["AllocCheck", "BandedMatrices", "BenchmarkTools", "BlockBandedMatrices", "FastAlmostBandedMatrices", "JLArrays", "SpecialMatrices", "Test", "ToeplitzMatrices"]


### PR DESCRIPTION
## Summary

This PR improves interface compatibility for the package:

- **Added ArrayInterface.jl dependency** for `fast_scalar_indexing` checks
- **Clear error messages for GPU arrays**: Instead of cryptic scalar indexing errors, users get informative `ArgumentError` messages explaining that GPU arrays are not supported
- **Relaxed type signatures**:
  - `getstructure`: `Matrix` → `AbstractMatrix`
  - `sparsestructure`: `SparseMatrixCSC` → `AbstractSparseMatrix`
- **Removed debug print statements** from `compute_bandedness`
- **Added interface tests** for BigFloat and JLArrays

## Interface Analysis

### What works
- ✅ **BigFloat**: All functions work correctly with `BigFloat` element types

### What doesn't work (by design)
- ❌ **GPU arrays (JLArrays)**: The algorithms fundamentally require scalar indexing to examine matrix structure element-by-element. This is not fixable without a complete algorithm redesign.

### Improvement
Previously, using GPU arrays resulted in cryptic errors like:
```
ErrorException("Scalar indexing is disallowed...")
```

Now users get clear, informative errors:
```
ArgumentError("is_toeplitz requires arrays with fast scalar indexing. GPU arrays are not supported for this operation.")
```

## Test Plan

- [x] All existing tests pass
- [x] New BigFloat interface tests pass
- [x] New JLArray error message tests pass
- [x] AbstractMatrix type genericity tests pass

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)