### PR TITLE
Move specialized matrix packages to weak dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,14 +4,23 @@ version = "1.0.0-DEV"
 authors = ["Anastasia Dunca"]
 
 [deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[weakdeps]
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
 FastAlmostBandedMatrices = "9d29842c-ecb8-4973-b1e9-a27b1157504e"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SemiseparableMatrices = "f8ebbe35-cbfb-4060-bf7f-b10e4670cf57"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SpecialMatrices = "928aab9d-ef52-54ac-8ca1-acd7ca42c160"
 ToeplitzMatrices = "c751599d-da0a-543b-9d20-d0a503d91d24"
+
+[extensions]
+BandedMatricesExt = "BandedMatrices"
+BlockBandedMatricesExt = ["BlockBandedMatrices", "BandedMatrices"]
+FastAlmostBandedMatricesExt = ["FastAlmostBandedMatrices", "BandedMatrices"]
+SpecialMatricesExt = "SpecialMatrices"
+ToeplitzMatricesExt = "ToeplitzMatrices"
 
 [compat]
 BandedMatrices = "1.10.2"
@@ -20,12 +29,17 @@ FastAlmostBandedMatrices = "0.1.5"
 SemiseparableMatrices = "0.4.0"
 SpecialMatrices = "3.1.0"
 ToeplitzMatrices = "0.8.5"
-julia = "1.6.7"
+julia = "1.9"
 
 [extras]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
+BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
+FastAlmostBandedMatrices = "9d29842c-ecb8-4973-b1e9-a27b1157504e"
+SpecialMatrices = "928aab9d-ef52-54ac-8ca1-acd7ca42c160"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+ToeplitzMatrices = "c751599d-da0a-543b-9d20-d0a503d91d24"
 
 [targets]
-test = ["AllocCheck", "BenchmarkTools", "Test"]
+test = ["AllocCheck", "BandedMatrices", "BenchmarkTools", "BlockBandedMatrices", "FastAlmostBandedMatrices", "SpecialMatrices", "Test", "ToeplitzMatrices"]

--- a/ext/BandedMatricesExt.jl
+++ b/ext/BandedMatricesExt.jl
@@ -1,0 +1,17 @@
+module BandedMatricesExt
+
+using SparseMatrixIdentification
+using BandedMatrices
+
+function __init__()
+    SparseMatrixIdentification._bandedmatrices_loaded[] = true
+end
+
+function SparseMatrixIdentification.try_banded(A, threshold)
+    if SparseMatrixIdentification.is_banded(A, threshold)
+        return BandedMatrix(A)
+    end
+    return nothing
+end
+
+end

--- a/ext/BlockBandedMatricesExt.jl
+++ b/ext/BlockBandedMatricesExt.jl
@@ -1,0 +1,22 @@
+module BlockBandedMatricesExt
+
+using SparseMatrixIdentification
+using BlockBandedMatrices
+using BandedMatrices
+
+function __init__()
+    SparseMatrixIdentification._blockbandedmatrices_loaded[] = true
+end
+
+function SparseMatrixIdentification.try_blockbanded(Ad, n)
+    blocksize = SparseMatrixIdentification.detect_block_size(Ad)
+    if blocksize > 0
+        nblocks = n ÷ blocksize
+        # Create BlockBandedMatrix with detected block structure
+        return BlockBandedMatrix{eltype(Ad)}(Ad, fill(blocksize, nblocks),
+            fill(blocksize, nblocks), (1, 1))
+    end
+    return nothing
+end
+
+end

--- a/ext/FastAlmostBandedMatricesExt.jl
+++ b/ext/FastAlmostBandedMatricesExt.jl
@@ -1,0 +1,33 @@
+module FastAlmostBandedMatricesExt
+
+using SparseMatrixIdentification
+using FastAlmostBandedMatrices
+using BandedMatrices
+
+function __init__()
+    SparseMatrixIdentification._fastalmostbandedmatrices_loaded[] = true
+end
+
+function SparseMatrixIdentification.try_almostbanded(Ad, n)
+    # Try different bandwidths
+    for bw in 1:min(5, n ÷ 2)
+        is_ab, bandwidth, rank = SparseMatrixIdentification.is_almost_banded(Ad, bw)
+        if is_ab
+            # Create AlmostBandedMatrix from FastAlmostBandedMatrices
+            # Extract banded part
+            banded_part = zeros(eltype(Ad), n, n)
+            for j in 1:n
+                for i in max(1, j - bw):min(n, j + bw)
+                    banded_part[i, j] = Ad[i, j]
+                end
+            end
+            B = BandedMatrix(banded_part, (bw, bw))
+            # For now, return the banded part as the structure is detected
+            # Full AlmostBandedMatrix construction requires more complex setup
+            return AlmostBandedMatrix(B, zeros(eltype(Ad), n, rank))
+        end
+    end
+    return nothing
+end
+
+end

--- a/ext/SpecialMatricesExt.jl
+++ b/ext/SpecialMatricesExt.jl
@@ -1,0 +1,46 @@
+module SpecialMatricesExt
+
+using SparseMatrixIdentification
+using SpecialMatrices
+
+function __init__()
+    SparseMatrixIdentification._specialmatrices_loaded[] = true
+end
+
+function SparseMatrixIdentification.try_special_matrices(Ad, n, m)
+    # Check for Hilbert matrix
+    if SparseMatrixIdentification.is_hilbert(Ad)
+        return Hilbert(n)
+    end
+
+    # Check for Strang matrix
+    if SparseMatrixIdentification.is_strang(Ad)
+        return Strang(n)
+    end
+
+    # Check for Vandermonde matrix
+    if SparseMatrixIdentification.is_vandermonde(Ad)
+        x = Ad[:, 2]  # Extract base values from second column
+        return Vandermonde(x)
+    end
+
+    # Check for Cauchy matrix
+    if SparseMatrixIdentification.is_cauchy(Ad)
+        # Extract x and y vectors for Cauchy matrix construction
+        y1 = 1.0 / Ad[1, 1]
+        x = zeros(Float64, n)
+        y = zeros(Float64, m)
+        y[1] = y1
+        for i in 2:n
+            x[i] = 1.0 / Ad[i, 1] - y[1]
+        end
+        for j in 2:m
+            y[j] = 1.0 / Ad[1, j] - x[1]
+        end
+        return Cauchy(x, y)
+    end
+
+    return nothing
+end
+
+end

--- a/ext/ToeplitzMatricesExt.jl
+++ b/ext/ToeplitzMatricesExt.jl
@@ -1,0 +1,19 @@
+module ToeplitzMatricesExt
+
+using SparseMatrixIdentification
+using ToeplitzMatrices
+
+function __init__()
+    SparseMatrixIdentification._toeplitzmatrices_loaded[] = true
+end
+
+function SparseMatrixIdentification.try_toeplitz(A)
+    if SparseMatrixIdentification.is_toeplitz(A)
+        first_row = A[1, :]
+        first_col = A[:, 1]
+        return Toeplitz(first_col, first_row)
+    end
+    return nothing
+end
+
+end


### PR DESCRIPTION
## Summary

This PR moves all specialized matrix packages to weak dependencies, significantly reducing load time and memory usage for users who only need basic matrix structure detection.

### Changes

- **Moved to weakdeps**: BandedMatrices, BlockBandedMatrices, FastAlmostBandedMatrices, SpecialMatrices, ToeplitzMatrices, SemiseparableMatrices
- **Kept as regular deps**: LinearAlgebra, SparseArrays (stdlib)
- **Created package extensions**:
  - `BandedMatricesExt`: enables `BandedMatrix` detection
  - `BlockBandedMatricesExt`: enables `BlockBandedMatrix` detection
  - `FastAlmostBandedMatricesExt`: enables `AlmostBandedMatrix` detection
  - `SpecialMatricesExt`: enables `Hilbert`, `Strang`, `Vandermonde`, `Cauchy` detection
  - `ToeplitzMatricesExt`: enables `Toeplitz` detection
- **Updated minimum Julia version** to 1.9 for native extension support

### Behavior

Without specialized packages loaded:
```julia
using SparseMatrixIdentification
using SparseArrays

A = sparse([1 2 2; 2 3 4; 2 4 5])
sparsestructure(A, 0.5)  # Returns Symmetric (from LinearAlgebra)
```

With specialized packages loaded:
```julia
using SparseMatrixIdentification
using SparseArrays
using SpecialMatrices  # Triggers SpecialMatricesExt

H = sparse(Matrix(Hilbert(4)))
sparsestructure(H, 0.5)  # Returns Hilbert(4)
```

## Test plan

- [x] All existing tests pass
- [x] Extensions precompile without warnings
- [x] Specialized types returned when packages are loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)