### PR TITLE
Canonicalize tests to @safetestset for per-unit module isolation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,6 +31,7 @@ BenchmarkTools = "1"
 BlockBandedMatrices = "0.13.4"
 FastAlmostBandedMatrices = "0.1.5"
 JLArrays = "0.1, 0.2, 0.3"
+SafeTestsets = "0.1, 1"
 SemiseparableMatrices = "0.4.0"
 SpecialMatrices = "3.1.0"
 Test = "1"
@@ -45,9 +46,10 @@ BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
 FastAlmostBandedMatrices = "9d29842c-ecb8-4973-b1e9-a27b1157504e"
 JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SpecialMatrices = "928aab9d-ef52-54ac-8ca1-acd7ca42c160"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ToeplitzMatrices = "c751599d-da0a-543b-9d20-d0a503d91d24"
 
 [targets]
-test = ["AllocCheck", "BandedMatrices", "BenchmarkTools", "BlockBandedMatrices", "FastAlmostBandedMatrices", "JLArrays", "Pkg", "SpecialMatrices", "Test", "ToeplitzMatrices"]
+test = ["AllocCheck", "BandedMatrices", "BenchmarkTools", "BlockBandedMatrices", "FastAlmostBandedMatrices", "JLArrays", "Pkg", "SafeTestsets", "SpecialMatrices", "Test", "ToeplitzMatrices"]

--- a/test/alloc_tests.jl
+++ b/test/alloc_tests.jl
@@ -2,6 +2,7 @@ using AllocCheck
 using SparseMatrixIdentification
 using SparseArrays
 using LinearAlgebra
+using Test
 
 @testset "AllocCheck - Zero Allocations" begin
     # Test check_diagonal - critical inner function

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SparseMatrixIdentification = "2607229e-3272-44a7-bc4a-cd97a328dfbf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
@@ -10,5 +11,6 @@ SparseMatrixIdentification = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
+SafeTestsets = "0.1, 1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,15 +1,16 @@
-using SparseMatrixIdentification
-using Aqua
-using JET
-using Test
+using SafeTestsets
 
-@testset "Aqua" begin
+@safetestset "Aqua" begin
+    using SparseMatrixIdentification
+    using Aqua
+    using Test
     # deps_compat is a genuine finding (missing compat for LinearAlgebra/SparseArrays
     # deps and the Pkg extra); keep every other sub-check enabled.
     Aqua.test_all(SparseMatrixIdentification; deps_compat = false)
     @test_broken false  # Aqua deps_compat: missing compat for LinearAlgebra, SparseArrays, Pkg — see https://github.com/SciML/SparseMatrixIdentification.jl/issues/36
 end
 
-@testset "JET" begin
+@safetestset "JET" begin
+    using Test
     @test_broken false  # JET: try_* extension helpers report no-matching-method in sparsestructure(::AbstractSparseMatrix) — see https://github.com/SciML/SparseMatrixIdentification.jl/issues/36
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,5 @@
 using Test
-using SparseMatrixIdentification
-using LinearAlgebra
-using SparseArrays
-using BandedMatrices
-using ToeplitzMatrices
-using SpecialMatrices
-using BlockBandedMatrices
-using FastAlmostBandedMatrices
-using JLArrays
+using SafeTestsets
 
 const GROUP = get(ENV, "GROUP", "All")
 
@@ -20,7 +12,10 @@ end
 
 if GROUP == "All" || GROUP == "Core"
 
-    @testset "Test check_diagonal" begin
+    @safetestset "Test check_diagonal" begin
+        using SparseMatrixIdentification
+        using LinearAlgebra
+        using Test
         A = [1 2 3; 4 1 5; 6 7 1]
         @test SparseMatrixIdentification.check_diagonal(A, 1, 1) == true   # Diagonal starting at (1, 1) should be all 1s
         @test SparseMatrixIdentification.check_diagonal(A, 1, 2) == false  # Diagonal starting at (1, 2) should not be all 1s
@@ -48,7 +43,9 @@ if GROUP == "All" || GROUP == "Core"
         @test SparseMatrixIdentification.check_diagonal(A, 1, 1) == false  # Diagonal starting at (1, 1) should not match, as 1 != 4
     end
 
-    @testset "Test is_toeplitz" begin
+    @safetestset "Test is_toeplitz" begin
+        using SparseMatrixIdentification
+        using Test
         # Test 1: A basic Toeplitz matrix (2x2)
         mat1 = [1 2; 3 1]
         @test SparseMatrixIdentification.is_toeplitz(mat1) == true
@@ -99,7 +96,10 @@ if GROUP == "All" || GROUP == "Core"
     end
 
     # Test for `compute_bandedness` function
-    @testset "Test compute_bandedness" begin
+    @safetestset "Test compute_bandedness" begin
+        using SparseMatrixIdentification
+        using LinearAlgebra
+        using Test
         # Test 1: Identity Matrix
         A = Matrix(I, 3, 3)
         bandwidth = 1
@@ -122,7 +122,10 @@ if GROUP == "All" || GROUP == "Core"
     end
 
     # Test for `is_banded` function
-    @testset "Test is_banded" begin
+    @safetestset "Test is_banded" begin
+        using SparseMatrixIdentification
+        using LinearAlgebra
+        using Test
         # Test 1: matrix with filled elements within the band
         A = [1 2 0; 3 4 5; 0 6 7]
         @test SparseMatrixIdentification.is_banded(A, 1 / 3) == false
@@ -137,7 +140,11 @@ if GROUP == "All" || GROUP == "Core"
     end
 
     # Test for `compute_sparsity` function
-    @testset "Test compute_sparsity" begin
+    @safetestset "Test compute_sparsity" begin
+        using SparseMatrixIdentification
+        using LinearAlgebra
+        using SparseArrays
+        using Test
         # Test 1: Identity matrix
         A = Matrix(I, 3, 3)
         A = SparseMatrixCSC(A)
@@ -155,7 +162,10 @@ if GROUP == "All" || GROUP == "Core"
     end
 
     # Test for `getstructure` function
-    @testset "Test getstructure" begin
+    @safetestset "Test getstructure" begin
+        using SparseMatrixIdentification
+        using LinearAlgebra
+        using Test
         # Test 1: Band matrix
         A = [1 2 0; 3 4 5; 0 6 7]
         @test getstructure(A) == (100.0, 0.2222222222222222)
@@ -166,7 +176,13 @@ if GROUP == "All" || GROUP == "Core"
     end
 
     # Test for `sparsestructure` function
-    @testset "Test sparsestructure" begin
+    @safetestset "Test sparsestructure" begin
+        using SparseMatrixIdentification
+        using LinearAlgebra
+        using SparseArrays
+        using BandedMatrices
+        using ToeplitzMatrices
+        using Test
 
         # Test 1: Sparse banded matrix (banded)
         A = [1 2 0; 3 4 5; 0 6 7]
@@ -200,7 +216,11 @@ if GROUP == "All" || GROUP == "Core"
     end
 
     # Test for SpecialMatrices detection (Issue #3)
-    @testset "Test SpecialMatrices detection" begin
+    @safetestset "Test SpecialMatrices detection" begin
+        using SparseMatrixIdentification
+        using SparseArrays
+        using SpecialMatrices
+        using Test
         # Test Hilbert matrix detection
         H = Matrix(Hilbert(4))
         @test SparseMatrixIdentification.is_hilbert(H) == true
@@ -238,7 +258,12 @@ if GROUP == "All" || GROUP == "Core"
     end
 
     # Test for BlockBandedMatrices detection (Issue #2)
-    @testset "Test BlockBandedMatrices detection" begin
+    @safetestset "Test BlockBandedMatrices detection" begin
+        using SparseMatrixIdentification
+        using SparseArrays
+        using BandedMatrices
+        using BlockBandedMatrices
+        using Test
         # Test block-banded detection helper
         # Create a 6x6 block-tridiagonal matrix with 2x2 blocks (non-symmetric, non-triangular)
         A = zeros(6, 6)
@@ -266,7 +291,9 @@ if GROUP == "All" || GROUP == "Core"
     end
 
     # Test for helper functions
-    @testset "Test helper functions" begin
+    @safetestset "Test helper functions" begin
+        using SparseMatrixIdentification
+        using Test
         # Test is_almost_banded helper function
         # Create a simple almost-banded matrix
         n = 10
@@ -292,7 +319,13 @@ if GROUP == "All" || GROUP == "Core"
     end
 
     # Interface compatibility tests
-    @testset "Interface Compatibility" begin
+    @safetestset "Interface Compatibility" begin
+        using SparseMatrixIdentification
+        using LinearAlgebra
+        using SparseArrays
+        using ToeplitzMatrices
+        using JLArrays
+        using Test
         @testset "BigFloat support" begin
             # Test that functions work with BigFloat element types
             A_bf = BigFloat[1 2 3; 4 1 2; 5 4 1]
@@ -347,7 +380,7 @@ if GROUP == "All" || GROUP == "Core"
         end
     end
 
-    @testset "Allocation Tests" begin
+    @safetestset "Allocation Tests" begin
         include("alloc_tests.jl")
     end
 


### PR DESCRIPTION
Convert the plain-`@testset` test units to `@safetestset` so each independent unit runs in its own module (isolation + world-age safety), matching the canonical SciML test structure (OrdinaryDiffEq et al.).

## What changed
- **test/runtests.jl**: each top-level `@testset` unit inside the `GROUP=="All"/"Core"` block becomes a `@safetestset`, each carrying its own `using`s (previously leaked from the shared top-of-file imports `SparseMatrixIdentification, LinearAlgebra, SparseArrays, BandedMatrices, ToeplitzMatrices, SpecialMatrices, BlockBandedMatrices, JLArrays`). Each unit gets only the imports its body actually references.
- Nested grouping `@testset`s inside the `Interface Compatibility` unit stay plain `@testset` (the unit-level `@safetestset` already isolates). The `Allocation Tests` unit stays `@safetestset begin include("alloc_tests.jl") end`.
- **test/alloc_tests.jl**: add `using Test` so the file is self-contained as a `@safetestset`-included module.
- **test/qa/qa.jl**: the `Aqua` and `JET` plain `@testset` units become `@safetestset`, each with its own `using`s. `@test_broken` markers preserved verbatim.
- Added `SafeTestsets` to the test deps (`[extras]`/`[targets].test` + `[compat] SafeTestsets = "0.1, 1"`) and to `test/qa/Project.toml` (the QA group activates its own environment).

## Behavior preserved
Same units, same assertions (68 `@test` + 5 `@test_throws`), same `GROUP`-dispatch ladder.

## Verification
Verified locally on Julia 1.11:
- `GROUP=Core`: all 12 units pass (e.g. Interface Compatibility 16/16, Allocation Tests 5/5).
- `GROUP=QA`: Aqua passes (enabled sub-checks); the two `@test_broken` markers register as Broken (preserved).

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)