### PR TITLE
Raise ArrayInterface compat floor to 7.1 (fix downgrade CI)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ ToeplitzMatricesExt = "ToeplitzMatrices"
 
 [compat]
 AllocCheck = "0.2"
-ArrayInterface = "7"
+ArrayInterface = "7.1"
 BandedMatrices = "1.10.2"
 BenchmarkTools = "1"
 BlockBandedMatrices = "0.13.4"


### PR DESCRIPTION
## Problem

The `downgrade / Downgrade Tests` check on `main` is red. The downgrade job pins `ArrayInterface` to its compat floor (`7.0.0`). At `7.0.0`, `ArrayInterface.fast_scalar_indexing(::JLArray)` returns `true` because the GPUArraysCore-aware definition that correctly reports `false` for GPU-backed arrays was only added in `ArrayInterface` `7.1.0`.

As a result, the `_require_fast_scalar_indexing` guard never fires on the downgrade floor: the package proceeds to scalar-index the GPU array, and GPUArrays throws a plain `ErrorException` ("Scalar indexing is disallowed.") instead of the package's intended `ArgumentError`. This breaks the `JLArray error messages` testset in `test/interface_compatibility_tests.jl`, which asserts an `ArgumentError` mentioning "fast scalar indexing" / "GPU arrays".

## Fix

Raise the `ArrayInterface` compat floor from `"7"` to `"7.1"`. The package's documented behavior (rejecting GPU arrays with a clear `ArgumentError`) only holds from `ArrayInterface` `7.1.0` onward, so `7.1` is the correct minimum bound.

## Verification (local, Julia 1.10.11)

Bisected `ArrayInterface` against `JLArrays 0.1.1` (the downgrade floor for JLArrays):

```
7.0.0 => fast_scalar_indexing=true   (guard never fires -> ErrorException, test fails)
7.1.0 => fast_scalar_indexing=false  (guard fires -> ArgumentError, test passes)
```

With `ArrayInterface 7.1.0` + `JLArrays 0.1.1`, all 8 assertions in the "JLArray error messages" testset pass:

```
[ Info: ArrayInterface=7.1.0 JLArrays=0.1.1 fast_scalar_indexing=false
Test Summary:          | Pass  Total  Time
JLArray error messages |    8      8  0.1s
```

Please ignore until reviewed by @ChrisRackauckas.
