### PR TITLE
docs: fix missing_docs and invalid-link errors (fix docs CI)

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -6,3 +6,16 @@
 getstructure
 sparsestructure
 ```
+
+## Extension Point Functions
+
+These functions are extension points that package extensions add methods to.
+They return `nothing` unless the corresponding optional package is loaded.
+
+```@docs
+SparseMatrixIdentification.try_special_matrices
+SparseMatrixIdentification.try_toeplitz
+SparseMatrixIdentification.try_banded
+SparseMatrixIdentification.try_blockbanded
+SparseMatrixIdentification.try_almostbanded
+```

--- a/src/SparseMatrixIdentification.jl
+++ b/src/SparseMatrixIdentification.jl
@@ -454,7 +454,7 @@ corresponding package is loaded. Load the relevant package to enable detection:
 # Returns
 One of the following matrix types based on detected structure:
 - `Hilbert`: If A[i,j] = 1/(i+j-1) (requires SpecialMatrices)
-- `Strang`: If the matrix is tridiagonal Toeplitz with pattern [2, -1, -1] (requires SpecialMatrices)
+- `Strang`: If the matrix is tridiagonal Toeplitz with pattern `[2, -1, -1]` (requires SpecialMatrices)
 - `Vandermonde`: If columns are powers of a base vector (requires SpecialMatrices)
 - `Cauchy`: If A[i,j] = 1/(x[i] + y[j]) (requires SpecialMatrices)
 - `Toeplitz`: If the matrix has constant diagonals (requires ToeplitzMatrices)


### PR DESCRIPTION
## Problem

The `docs / Build and Deploy Documentation` check on `main` is red. `makedocs` terminates at the CheckDocument/CrossReferences stage with two errors, both of which reproduce on a clean `main`:

1. **`:missing_docs`** — five extension-point functions (`try_special_matrices`, `try_toeplitz`, `try_banded`, `try_blockbanded`, `try_almostbanded`) carry docstrings but are not referenced from any `@docs`/`@autodocs` block, while `docs/make.jl` passes `modules = [SparseMatrixIdentification]`.

2. **`:cross_references`** — the `sparsestructure` docstring contains `[2, -1, -1] (requires SpecialMatrices)`, which Markdown parses as a link with text `2, -1, -1` and a nonexistent local destination `requires SpecialMatrices`.

(Only `:missing_docs` is visible at the top of the CI log, but Documenter collects both error categories; both must be fixed for the build to go green.)

## Fix

1. Add an "Extension Point Functions" section to `docs/src/api.md` listing the five `try_*` extension points.
2. Wrap `[2, -1, -1]` in backticks in the `sparsestructure` docstring so it renders as inline code rather than a link.

## Verification (local, Julia 1.10.11)

`makedocs` (linkcheck disabled for the offline run; that stage is independent of these two checks) now completes:

```
MAKEDOCS_OK_FINAL
```

with no `:missing_docs` and no `:cross_references` errors. On clean `main` the same build emits:

```
ERROR: LoadError: `makedocs` encountered errors [:missing_docs, :cross_references] -- terminating build before rendering.
```

Runic leaves the edited source file unchanged.

Please ignore until reviewed by @ChrisRackauckas.
