### PR TITLE
Fix downgrade CI: add GPUArrays compat floor (8.4) and raise ArrayInterface to 7.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,6 +30,7 @@ BandedMatrices = "1.10.2"
 BenchmarkTools = "1"
 BlockBandedMatrices = "0.13.4"
 FastAlmostBandedMatrices = "0.1.5"
+GPUArrays = "8.4, 9, 10, 11"
 JLArrays = "0.1, 0.2, 0.3"
 SafeTestsets = "0.0.1, 0.1, 1"
 SciMLTesting = "1"
@@ -45,6 +46,7 @@ BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
 FastAlmostBandedMatrices = "9d29842c-ecb8-4973-b1e9-a27b1157504e"
+GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
@@ -53,4 +55,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ToeplitzMatrices = "c751599d-da0a-543b-9d20-d0a503d91d24"
 
 [targets]
-test = ["AllocCheck", "BandedMatrices", "BenchmarkTools", "BlockBandedMatrices", "FastAlmostBandedMatrices", "JLArrays", "SafeTestsets", "SciMLTesting", "SpecialMatrices", "Test", "ToeplitzMatrices"]
+test = ["AllocCheck", "BandedMatrices", "BenchmarkTools", "BlockBandedMatrices", "FastAlmostBandedMatrices", "GPUArrays", "JLArrays", "SafeTestsets", "SciMLTesting", "SpecialMatrices", "Test", "ToeplitzMatrices"]

--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ ToeplitzMatricesExt = "ToeplitzMatrices"
 
 [compat]
 AllocCheck = "0.2"
-ArrayInterface = "7.1"
+ArrayInterface = "7.7"
 BandedMatrices = "1.10.2"
 BenchmarkTools = "1"
 BlockBandedMatrices = "0.13.4"


### PR DESCRIPTION
## Fix downgrade CI failure (`interface_compatibility_tests.jl` JLArray testset)

The `downgrade` job was failing in the **JLArray error messages** testset (8 passed / 8 failed).

### Root cause
The package guards against GPU arrays with `ArrayInterface.fast_scalar_indexing(A)` and throws a friendly `ArgumentError` ("requires arrays with fast scalar indexing. GPU arrays are not supported"). The test feeds a `JLArray` and asserts that `ArgumentError`.

During downgrade resolution, `GPUArrays` is pulled in **transitively** via `JLArrays 0.1.1` and resolves to its floor `8.1.3`. At GPUArrays `< 8.4`, `ArrayInterface.fast_scalar_indexing(::JLArray)` returns `true`, so the package guard never fires; the code scalar-indexes the JLArray and GPUArrays raises its own `ErrorException("Scalar indexing is disallowed...")` instead of the expected `ArgumentError`. `fast_scalar_indexing` first returns `false` for `JLArray` at GPUArrays **8.4.0**.

Bisected locally on Julia 1.10 (lts) with the CI-resolved `ArrayInterface 7.7.0` / `JLArrays 0.1.1`:

| GPUArrays | `fast_scalar_indexing(JLArray)` | interface test |
|-----------|-----|------|
| 8.1.3 (CI) | `true` | 8/8 FAIL (reproduces CI) |
| 8.3.2 | `true` | fail |
| **8.4.0** | `false` | **16/16 PASS** |
| 11.5.8 (newest) | `false` | pass |

### Fix
Add an explicit `GPUArrays` compat floor (`8.4, 9, 10, 11`) plus the matching `[extras]`/test-target entries, so downgrade resolution cannot pick the broken `< 8.4` series. (The earlier `ArrayInterface` 7.1 → 7.7 floor bump remains, addressing the original Adapt/ArrayInterface resolution issue.)

### Local verification (Julia 1.10.11)
- GPUArrays 8.1.3 + JLArrays 0.1.1 + ArrayInterface 7.7.0 → `interface_compatibility_tests.jl`: 8 pass / 8 fail (reproduces CI).
- GPUArrays 8.4.0 (new floor) + same → 16/16 pass.
- Full `GROUP=Core` `Pkg.test()` on lts at normal resolution → all green.

Please ignore until reviewed by @ChrisRackauckas