### PR TITLE
Bump version to 1.1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SparseMatrixIdentification"
 uuid = "2607229e-3272-44a7-bc4a-cd97a328dfbf"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Anastasia Dunca"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (1.1.0 -> 1.1.1) to release unreleased commits on `main` via JuliaRegistrator.