### PR TITLE
Release prep: bump SparseMatrixIdentification to 1.1.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SparseMatrixIdentification"
 uuid = "2607229e-3272-44a7-bc4a-cd97a328dfbf"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Anastasia Dunca"]
 
 [deps]


### PR DESCRIPTION
Patch release covering the accumulated docstring, docs QA config, and test/QA scaffolding changes since 1.1.1; no functional or API changes.