### PR TITLE
Sync package versions with the General registry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SparseMatrixIdentification"
 uuid = "2607229e-3272-44a7-bc4a-cd97a328dfbf"
-version = "1.1.2"
+version = "1.1.3"
 authors = ["Anastasia Dunca"]
 
 [deps]


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What this changes

| package | from | to | why |
|---|---|---|---|
| `SparseMatrixIdentification` | 1.1.2 | 1.1.3 | unreleased changes with no version bump |


## Why

Each `to` is the next sequential version after what is currently registered in
General. Versions that skip an unregistered version are rejected by AutoMerge's
sequential version number guideline, so they can never be registered as-is;
packages with unreleased changes and no bump cannot be registered at all.

Only the top-level `version` field of each `Project.toml` is touched.

After merge, each package still needs `@JuliaRegistrator register` (with
`subdir=` where applicable).