### PR TITLE
QA: scan the package extensions with ExplicitImports

### DIFF
--- a/ext/BandedMatricesExt.jl
+++ b/ext/BandedMatricesExt.jl
@@ -1,7 +1,7 @@
 module BandedMatricesExt
 
-using SparseMatrixIdentification
-using BandedMatrices
+using SparseMatrixIdentification: SparseMatrixIdentification
+using BandedMatrices: BandedMatrix
 
 function __init__()
     return SparseMatrixIdentification._bandedmatrices_loaded[] = true

--- a/ext/BlockBandedMatricesExt.jl
+++ b/ext/BlockBandedMatricesExt.jl
@@ -1,8 +1,7 @@
 module BlockBandedMatricesExt
 
-using SparseMatrixIdentification
-using BlockBandedMatrices
-using BandedMatrices
+using SparseMatrixIdentification: SparseMatrixIdentification
+using BlockBandedMatrices: BlockBandedMatrix
 
 function __init__()
     return SparseMatrixIdentification._blockbandedmatrices_loaded[] = true

--- a/ext/FastAlmostBandedMatricesExt.jl
+++ b/ext/FastAlmostBandedMatricesExt.jl
@@ -1,8 +1,8 @@
 module FastAlmostBandedMatricesExt
 
-using SparseMatrixIdentification
-using FastAlmostBandedMatrices
-using BandedMatrices
+using SparseMatrixIdentification: SparseMatrixIdentification
+using FastAlmostBandedMatrices: AlmostBandedMatrix
+using BandedMatrices: BandedMatrix
 
 function __init__()
     return SparseMatrixIdentification._fastalmostbandedmatrices_loaded[] = true

--- a/ext/SpecialMatricesExt.jl
+++ b/ext/SpecialMatricesExt.jl
@@ -1,7 +1,7 @@
 module SpecialMatricesExt
 
-using SparseMatrixIdentification
-using SpecialMatrices
+using SparseMatrixIdentification: SparseMatrixIdentification
+using SpecialMatrices: Cauchy, Hilbert, Strang, Vandermonde
 
 function __init__()
     return SparseMatrixIdentification._specialmatrices_loaded[] = true

--- a/ext/ToeplitzMatricesExt.jl
+++ b/ext/ToeplitzMatricesExt.jl
@@ -1,7 +1,7 @@
 module ToeplitzMatricesExt
 
-using SparseMatrixIdentification
-using ToeplitzMatrices
+using SparseMatrixIdentification: SparseMatrixIdentification
+using ToeplitzMatrices: Toeplitz
 
 function __init__()
     return SparseMatrixIdentification._toeplitzmatrices_loaded[] = true

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,13 +1,23 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
+BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
+FastAlmostBandedMatrices = "9d29842c-ecb8-4973-b1e9-a27b1157504e"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SparseMatrixIdentification = "2607229e-3272-44a7-bc4a-cd97a328dfbf"
+SpecialMatrices = "928aab9d-ef52-54ac-8ca1-acd7ca42c160"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+ToeplitzMatrices = "c751599d-da0a-543b-9d20-d0a503d91d24"
 
 [compat]
 Aqua = "0.8"
+BandedMatrices = "1.10.2"
+BlockBandedMatrices = "0.13.4"
+FastAlmostBandedMatrices = "0.1.5"
 JET = "0.9,0.10,0.11"
 SciMLTesting = "2.4"
+SpecialMatrices = "3.1.0"
 Test = "1"
+ToeplitzMatrices = "0.8.5"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,4 +1,33 @@
 using SciMLTesting, SparseMatrixIdentification
 using JET
 
-run_qa(SparseMatrixIdentification)
+# ExplicitImports only sees an extension module once its trigger packages are loaded
+# (`Base.get_extension` returns `nothing` otherwise), so load every weakdep here to put
+# the extensions under QA. The `SemiseparableMatrices` weakdep has no `[extensions]`
+# entry, so there is no extension module for it to scan.
+using BandedMatrices, BlockBandedMatrices, FastAlmostBandedMatrices
+using SpecialMatrices, ToeplitzMatrices
+
+run_qa(
+    SparseMatrixIdentification;
+    ei_kwargs = (;
+        all_qualified_accesses_are_public = (;
+            # Owner: SparseMatrixIdentification itself. Every one of these is the
+            # package's own internals reached from its own extension modules, which is
+            # the only way an extension can hook into its parent: the `try_*` stubs are
+            # the methods each extension adds, the `_*_loaded` `Ref`s are the flags the
+            # extension's `__init__` flips, and the `is_*`/`detect_*` predicates are the
+            # structure detectors the extension dispatches on. None of them are declared
+            # `public`, and there is no public spelling to use instead.
+            ignore = (
+                :_bandedmatrices_loaded, :_blockbandedmatrices_loaded,
+                :_fastalmostbandedmatrices_loaded, :_specialmatrices_loaded,
+                :_toeplitzmatrices_loaded,
+                :try_almostbanded, :try_banded, :try_blockbanded,
+                :try_special_matrices, :try_toeplitz,
+                :detect_block_size, :is_almost_banded, :is_banded, :is_cauchy,
+                :is_hilbert, :is_strang, :is_toeplitz, :is_vandermonde,
+            ),
+        ),
+    ),
+)


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Why

`SciMLTesting.run_qa` runs ExplicitImports' checks on the package module.
ExplicitImports *does* know about package extensions — it reads the `[extensions]`
table out of `Project.toml` — but it skips any extension whose module does not
exist, and an extension module only comes into existence once its trigger
(weak)dependency is loaded:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

`test/qa/Project.toml` did not depend on any of this package's weakdeps, so **none
of the five extensions were being scanned by QA at all**. Verified on the base
branch (`main`), from the unmodified QA environment:

```
BandedMatricesExt => nothing
BlockBandedMatricesExt => nothing
FastAlmostBandedMatricesExt => nothing
SpecialMatricesExt => nothing
ToeplitzMatricesExt => nothing
SCANNED: SparseMatrixIdentification
```

This was a real gap, not an incidental one — no test dependency was pulling any of
the weakdeps in transitively.

## What changed

* `test/qa/Project.toml`: added `BandedMatrices`, `BlockBandedMatrices`,
  `FastAlmostBandedMatrices`, `SpecialMatrices`, `ToeplitzMatrices` under `[deps]`
  (same UUIDs as the root `[weakdeps]`) with `[compat]` entries mirroring the root
  `Project.toml` bounds.
* `test/qa/qa.jl`: `using` all five so the extension modules exist by the time
  `run_qa` runs.

Same probe on this branch:

```
BandedMatricesExt => BandedMatricesExt
BlockBandedMatricesExt => BlockBandedMatricesExt
FastAlmostBandedMatricesExt => FastAlmostBandedMatricesExt
SpecialMatricesExt => SpecialMatricesExt
ToeplitzMatricesExt => ToeplitzMatricesExt
SemiseparableMatricesExt => nothing
SCANNED: FastAlmostBandedMatricesExt
SCANNED: SparseMatrixIdentification
SCANNED: BlockBandedMatricesExt
SCANNED: BandedMatricesExt
SCANNED: SpecialMatricesExt
SCANNED: ToeplitzMatricesExt
```

### Coverage

All 5 declared extensions are now scanned. Nothing was left out for
hardware/system-library reasons — every weakdep here is pure Julia.

`SemiseparableMatrices` is declared under `[weakdeps]` and `[compat]` in the root
`Project.toml` but has **no `[extensions]` entry and no `ext/` file**, so there is
no extension module for ExplicitImports to scan. It is a dangling weakdep; adding
it to the QA environment would achieve nothing, so it was left out. Worth removing
from `[weakdeps]`/`[compat]` (or growing the extension it was presumably meant to
trigger) in a separate PR.

## Findings the new coverage produced, and how each was handled

### Fixed in the extension sources (`no_implicit_imports`)

Every extension did `using SomePackage` and then used names from it implicitly.
Replaced with explicit imports:

| file | before | after |
| --- | --- | --- |
| `ext/BandedMatricesExt.jl` | `using SparseMatrixIdentification`, `using BandedMatrices` | `using SparseMatrixIdentification: SparseMatrixIdentification`, `using BandedMatrices: BandedMatrix` |
| `ext/BlockBandedMatricesExt.jl` | + `using BlockBandedMatrices`, `using BandedMatrices` | `using BlockBandedMatrices: BlockBandedMatrix` (the `BandedMatrices` `using` was dropped — nothing from it was used; it remains a declared trigger in `[extensions]`) |
| `ext/FastAlmostBandedMatricesExt.jl` | + `using FastAlmostBandedMatrices`, `using BandedMatrices` | `using FastAlmostBandedMatrices: AlmostBandedMatrix`, `using BandedMatrices: BandedMatrix` |
| `ext/SpecialMatricesExt.jl` | + `using SpecialMatrices` | `using SpecialMatrices: Cauchy, Hilbert, Strang, Vandermonde` |
| `ext/ToeplitzMatricesExt.jl` | + `using ToeplitzMatrices` | `using ToeplitzMatrices: Toeplitz` |

No behavior change; `GROUP=Core` still passes (see below).

### Ignored, with justification (`all_qualified_accesses_are_public`)

18 findings, and **all 18 have `SparseMatrixIdentification` itself as the owner** —
they are the extensions reaching into their own parent package, which is the only
way an extension can hook into it. One ignore group was added in `test/qa/qa.jl`
with a comment naming the owner and the reason:

* `try_almostbanded`, `try_banded`, `try_blockbanded`, `try_special_matrices`,
  `try_toeplitz` — the stub functions each extension adds methods to.
* `_bandedmatrices_loaded`, `_blockbandedmatrices_loaded`,
  `_fastalmostbandedmatrices_loaded`, `_specialmatrices_loaded`,
  `_toeplitzmatrices_loaded` — the `Ref{Bool}` flags each extension's `__init__`
  flips.
* `detect_block_size`, `is_almost_banded`, `is_banded`, `is_cauchy`, `is_hilbert`,
  `is_strang`, `is_toeplitz`, `is_vandermonde` — the structure-detection predicates
  the extensions dispatch on.

None of these are declared `public`/exported, and there is no public spelling to
use instead, so there is nothing to "fix" in the extension source. No check was
disabled and no `@test_broken` was added.

Follow-up worth considering (deliberately **not** done here to keep this PR
reviewable): the five `try_*` functions are already documented in
`docs/src/api.md` under "Extension Point Functions", i.e. they are de-facto public
API that has never been declared `public`. Declaring them `public` (a minor
version bump) would let five of the eighteen ignores be dropped.

## Local results

`GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'` on Julia 1.12:

```
Test Summary: | Pass  Total     Time
QA/qa.jl      |   21     21  1m15.2s
     Testing SparseMatrixIdentification tests passed
```

Before this PR, the same command on this branch's `test/qa` content but without
the source fixes errored with `no_implicit_imports` and
`all_qualified_accesses_are_public` — i.e. the newly-scanned extensions did
produce real findings, which is the point.

`GROUP=Core julia --project=. -e 'using Pkg; Pkg.test()'` also passes with the
extension source changes (`Testing SparseMatrixIdentification tests passed`, all
12 test files green).

`test/qa/Manifest.toml` is a local build artifact and is not committed.
