### PR TITLE
Add PrecompileTools workload

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ authors = ["Anastasia Dunca"]
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [weakdeps]
@@ -33,6 +34,7 @@ FastAlmostBandedMatrices = "0.1.5"
 GPUArrays = "10.3.1, 11"
 JLArrays = "0.1, 0.2, 0.3"
 LinearAlgebra = "1"
+PrecompileTools = "1.2"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "2.4"
 SemiseparableMatrices = "0.4.0"

--- a/src/SparseMatrixIdentification.jl
+++ b/src/SparseMatrixIdentification.jl
@@ -570,4 +570,16 @@ function sparsestructure(A::AbstractSparseMatrix, threshold)
     return SparseMatrixCSC(A)
 end
 
+using PrecompileTools: @compile_workload, @setup_workload
+
+@setup_workload begin
+    @compile_workload begin
+        A = [1.0 2.0 0.0; 2.0 4.0 5.0; 0.0 5.0 6.0]
+        getstructure(A)
+        is_toeplitz(A)
+        is_hilbert([1.0 0.5; 0.5 1 / 3])
+        sparsestructure(SparseMatrixCSC(A), 1 / 3)
+    end
+end
+
 end


### PR DESCRIPTION
## Summary
Adds a PrecompileTools workload covering representative public APIs so the package common execution path is compiled during precompilation.

## Verification
The branch was validated locally with package load/precompile, a focused workload smoke test, and repository checks where available. Runic, typos, and git diff --check were checked for the change.

## Known limitations
No additional limitation was observed in the focused verification.

This draft should be ignored until reviewed by @ChrisRackauckas.