### PR TITLE
Bump versions for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SparseMatrixIdentification"
 uuid = "2607229e-3272-44a7-bc4a-cd97a328dfbf"
-version = "1.1.4"
+version = "1.2.0"
 authors = ["Anastasia Dunca"]
 
 [deps]


### PR DESCRIPTION
Bumps the version(s) below so the src changes already merged to `main` can be registered in the General registry.

- SparseMatrixIdentification: 1.1.4 -> 1.2.0

No code changes — version metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
